### PR TITLE
Update actions/setup-node v1 -> v4

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,14 +8,9 @@ jobs:
         node-version: [10.x, 14.x]
     steps:
     - uses: actions/checkout@v2
-    - uses: actions/setup-node@v1
+    - uses: actions/setup-node@v4
       with:
         node-version: ${{ matrix.node-version }}
-    - name: Cache Node.js modules
-      uses: actions/cache@v1
-      with:
-        path: ${{ github.workspace }}/node_modules
-        key: ${{ runner.OS }}-${{ matrix.node-version}}-node_modules-${{ hashFiles('yarn.lock') }}
     - run: yarn --frozen-lockfile
     - run: yarn lint --max-warnings=0
     - run: yarn test --coverage


### PR DESCRIPTION
Current versions of these actions include modules caching, so the separate cache step (which uses a version of `actions/cache` that will stop working next month) can be removed.